### PR TITLE
Use /bin/readlink when available (e.g. on Ubuntu).

### DIFF
--- a/features/com.aptana.feature.rcp/linux/studio3
+++ b/features/com.aptana.feature.rcp/linux/studio3
@@ -5,7 +5,12 @@ SELF_LOCATION=$(cd "$(dirname "$0")" ; pwd)
 # Was this invoked as a link ?
 if [ -L "$0" ]
 then
-	LINKTO=$(/usr/bin/readlink "$0")
+	if [ -x /bin/readlink ]
+	then
+		LINKTO=$(/bin/readlink "$0")
+	else
+		LINKTO=$(/usr/bin/readlink "$0")
+	fi
 
 	# Is the link a relative path
 	if [[ "${LINKTO}" = /* ]]


### PR DESCRIPTION
On Ubuntu there's no `/usr/bin/readlink` as you can check on [packages.ubuntu.com](http://packages.ubuntu.com/search?searchon=contents&keywords=readlink&mode=exactfilename&suite=oneiric&arch=any). The correct file is `/bin/readlink`.

This patch looks for `/bin/readlink` before `/usr/bin/readlink`.
