### PR TITLE
TISTUD-6548 Studio installer version on Mac displays 3.0 despite being 3.3.0

### DIFF
--- a/builders/com.aptana.rcp.build/build_local.properties
+++ b/builders/com.aptana.rcp.build/build_local.properties
@@ -51,7 +51,8 @@ base=${buildDirectory}
 baseLocation=${base}/eclipse
 repoBaseLocation=${base}/repoBase
 transformedRepoLocation=${base}/transformedRepos
-version.full=3.6.0.${build.revision}
+version.short=3.6.0
+version.full=${version.short}.${build.revision}
 product.name=AptanaStudio3
 
 topLevelElementType = product

--- a/builders/com.aptana.rcp.build/custom/macosx/Info.plist
+++ b/builders/com.aptana.rcp.build/custom/macosx/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>AptanaStudio3</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Aptana Studio 3 for Mac OS X, Copyright Appcelerator, Inc. 2011-2013. All rights reserved.</string>
+	<string>Aptana Studio 3 for Mac OS X, Copyright Appcelerator, Inc. 2011-%year%. All rights reserved.</string>
 	<key>CFBundleIconFile</key>
 	<string>aptana.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1</string>
+	<string>0.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>APTS</string>
 	<key>CFBundleVersion</key>
-	<string>3.1</string>
+	<string>0.0.0.qualifier</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/builders/com.aptana.rcp.build/customTargets.xml
+++ b/builders/com.aptana.rcp.build/customTargets.xml
@@ -20,6 +20,9 @@
 		<tstamp>
 			<format property="short.timestamp" pattern="ddMMyyyyHHmmss" locale="en" />
 		</tstamp>
+		<tstamp>
+			<format property="year" pattern="yyyy" locale="en" />
+		</tstamp>
 		<echo message="Updating versions in feature and plugin manifests. Full version: ${version.full}, qualifier: ${build.revision}" />
 		<!-- Replace very specific files (taken from our old build) -->
 		<replace file="${buildDirectory}/plugins${product}" token="0.0.0.qualifier" value="${version.full}-${short.timestamp}" />
@@ -30,6 +33,11 @@
 		<replace file="${buildDirectory}/features/com.aptana.feature.rcp/feature.properties" token="build.name" value="${build.name}" />
 		<replace file="${buildDirectory}/features/com.aptana.feature.rcp/rootfiles/version.txt" token="0.0.0" value="${version.full}" />
 		<replace file="${buildDirectory}/features/com.aptana.feature.rcp/rootfiles/version.txt" token=".qualifier" value="${build.revision}" />
+	
+		<!-- Inject year and versions into Info.plist -->
+		<replace file="${builder}/custom/macosx/Info.plist" token="0.0.0.qualifier" value="${version.full}" />
+		<replace file="${builder}/custom/macosx/Info.plist" token="%year%" value="${year}" />
+		<replace file="${builder}/custom/macosx/Info.plist" token="0.0.0" value="${version.short}" />
 	</target>
 
 	<!-- ===================================================================== -->

--- a/features/com.aptana.feature.rcp/rootfiles/configuration/.settings/org.eclipse.equinox.p2.artifact.repository.prefs
+++ b/features/com.aptana.feature.rcp/rootfiles/configuration/.settings/org.eclipse.equinox.p2.artifact.repository.prefs
@@ -1,6 +1,6 @@
 #Thu May 22 16:08:17 EDT 2008
 eclipse.preferences.version=1
-repositories/http\:__download.eclipse.org_releases_indigo/url=http\://download.eclipse.org/releases/indigo
-repositories/http\:__download.eclipse.org_releases_indigo/isSystem=false
-repositories/http\:__download.eclipse.org_releases_indigo/enabled=true
-repositories/http\:__download.eclipse.org_releases_indigo/name=Indigo Update Site
+repositories/http\:__download.eclipse.org_releases_kepler/url=http\://download.eclipse.org/releases/kepler
+repositories/http\:__download.eclipse.org_releases_kepler/isSystem=false
+repositories/http\:__download.eclipse.org_releases_kepler/enabled=true
+repositories/http\:__download.eclipse.org_releases_kepler/name=Kelper Update Site

--- a/features/com.aptana.feature.rcp/rootfiles/configuration/.settings/org.eclipse.equinox.p2.metadata.repository.prefs
+++ b/features/com.aptana.feature.rcp/rootfiles/configuration/.settings/org.eclipse.equinox.p2.metadata.repository.prefs
@@ -1,8 +1,8 @@
 #Thu May 22 16:08:18 EDT 2008
 eclipse.preferences.version=1
-repositories/http\:__download.eclipse.org_releases_indigo/version=1.0.0
-repositories/http\:__download.eclipse.org_releases_indigo/type=org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository
-repositories/http\:__download.eclipse.org_releases_indigo/url=http\://download.eclipse.org/releases/indigo
-repositories/http\:__download.eclipse.org_releases_indigo/enabled=true
-repositories/http\:__download.eclipse.org_releases_indigo/isSystem=false
-repositories/http\:__download.eclipse.org_releases_indigo/name=Indigo Update Site
+repositories/http\:__download.eclipse.org_releases_kepler/version=1.0.0
+repositories/http\:__download.eclipse.org_releases_kepler/type=org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository
+repositories/http\:__download.eclipse.org_releases_kepler/url=http\://download.eclipse.org/releases/kepler
+repositories/http\:__download.eclipse.org_releases_kepler/enabled=true
+repositories/http\:__download.eclipse.org_releases_kepler/isSystem=false
+repositories/http\:__download.eclipse.org_releases_kepler/name=Kepler Update Site


### PR DESCRIPTION
- Inject versions and year into Info.plist as part of our build rather than relying on updating it ourselves
- Fix the update site we point at to Kelper from Indigo (since we now build on 4.3 as our base).
